### PR TITLE
Add more links in snapcraft.yaml

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -7,8 +7,9 @@ description: |
 confinement: classic
 base: core22
 website: https://zellij.dev
-source-code: https://github.com/dominz88/zellij-snap
 issues: https://github.com/zellij-org/zellij/issues
+source-code: https://github.com/dominz88/zellij-snap
+contact: dominguez.lopez.luis.alonso@laposte.net
 
 architectures:
   - build-on: amd64

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -6,6 +6,9 @@ description: |
   terminal environment.
 confinement: classic
 base: core22
+website: https://zellij.dev
+source-code: https://github.com/dominz88/zellij-snap
+issues: https://github.com/zellij-org/zellij/issues
 
 architectures:
   - build-on: amd64


### PR DESCRIPTION
This PR adds a few more links in snapcraft.yaml.
Specifically, added a backlink to this snap repo, so it is easy to find from the snapcraft.io page.

To make use of these new fields, need to enable it in the settings tab of the snap listing page:
![image](https://github.com/user-attachments/assets/a25fa2ea-1c75-45a2-ac67-c6d58e1805b1)
