### PR TITLE
ci: add CI workflows for publishing and promotion

### DIFF
--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -1,0 +1,15 @@
+name: Promote candidate -> stable
+
+on:
+  workflow_dispatch:
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Promote snap to stable
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_TOKEN }}
+        run: |
+          sudo snap install --classic snapcraft
+          snapcraft promote zellij --from-channel latest/candidate --to-channel latest/stable --yes

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -1,0 +1,33 @@
+name: CI (Pull Request)
+
+on:
+  pull_request:
+    branches: ["main"]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  snap:
+    name: Build snap
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-24.04
+          - os: ubuntu-24.04-arm
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup LXD
+        uses: canonical/setup-lxd@v0.1.2
+
+      - name: Setup Snapcraft
+        run: sudo snap install --classic snapcraft
+
+      - name: Build snap
+        run: snapcraft --verbose

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -37,3 +37,36 @@ jobs:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_TOKEN }}
         run: |
           snapcraft upload zellij_*.snap --release latest/candidate
+
+  notify:
+    name: Call for testing
+    needs: [snap]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Open promotion prompt
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="$(yq '.version' snapcraft.yaml)"
+          gh issue create \
+            --title "Call for testing: zellij \`$VERSION\` on \`latest/candidate\`" \
+            --body "The \`zellij\` snap was updated automatically to version \`$VERSION\` and released to the \`latest/candidate\` channel, and now needs testing for promotion to \`latest/stable\`.
+
+          If you already have the snap installed, you can test the snap by running:
+
+              sudo snap refresh zellij --channel latest/candidate
+
+          Or you can install the snap with:
+
+              sudo snap install zellij --channel latest/candidate
+
+          As the maintainer of the snap, you can effect the promotion at the CLI with the command below, or by dispatching the [promotion workflow](https://github.com/dominz88/zellij-snap/actions/workflows/promote.yaml):
+
+              snapcraft promote zellij --from-channel latest/candidate --to-channel latest/stable --yes
+
+          "

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -1,0 +1,39 @@
+name: CI (Push)
+
+on:
+  push:
+    branches: ["main"]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  snap:
+    name: Build snap
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-24.04
+          - os: ubuntu-24.04-arm
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup LXD
+        uses: canonical/setup-lxd@v0.1.2
+
+      - name: Setup Snapcraft
+        run: sudo snap install --classic snapcraft
+
+      - name: Build snap
+        run: snapcraft --verbose
+
+      - name: Release snap
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_TOKEN }}
+        run: |
+          snapcraft upload zellij_*.snap --release latest/candidate

--- a/.github/workflows/update-snap.yaml
+++ b/.github/workflows/update-snap.yaml
@@ -1,0 +1,65 @@
+name: Update
+
+on:
+  # Runs at 10:00 UTC every day
+  schedule:
+    - cron: "0 10 * * *"
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sync:
+    name: Sync version with upstream
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the source
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sync Version
+        id: version
+        run: |
+          LATEST=$(curl -sL https://api.github.com/repos/zellij-org/zellij/releases |
+            jq .  | grep tag_name | head -n 1 | cut -d'"' -f4 | tr -d 'v'
+          )
+          sed -i 's/^\(version: \).*$/\1'"$LATEST"'/' snap/snapcraft.yaml
+          echo "version=$(LATEST)" >> $GITHUB_OUTPUT
+
+      - name: Detect changes
+        id: changes
+        run: |
+          if [[ -z "$(git status --porcelain)" ]]; then
+            echo "No changes detected"
+            echo "updated=true" >> $GITHUB_OUTPUT
+          fi
+          echo "updated=false" >> $GITHUB_OUTPUT
+
+      - name: Setup LXD
+        if: ${{ steps.changes.outputs.test == 'true' }}
+        uses: canonical/setup-lxd@v0.1.2
+
+      - name: Ensure snap builds
+        if: ${{ steps.changes.outputs.test == 'true' }}
+        run: |
+          sudo snap install --classic snapcraft
+          snapcraft --verbose
+
+      - name: Open issue if failed
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue create --title "Auto-update to version \`${{ steps.version.outputs.version }}\` failed" --body "Attempted to update snap automatically, but build failed. See: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID} for details."
+
+      - name: Commit changes
+        if: ${{ steps.changes.outputs.test == 'true' }}
+        run: |
+          git config --global user.name "Github Actions"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -am "chore: bump zellij to version `${{ steps.version.outputs.version }}`"
+          git push


### PR DESCRIPTION
This commit adds 4 Github workflows:

`push.yaml` runs when there are pushes to the
`main` branch, builds the snap and uploads it to
the Snap store automatically, releasing the built
artifact to the `latest/candidate` channel.

`pull-request.yaml` executes on Pull Requests, and simply 
checks the Snap builds correctly.

`update-snap.yaml` runs at 10:00 UTC every day,
watching for new releases, and automatically
committing and updated `snapcraft.yaml` to
the `main` branch, assuming that the Snap builds.

`promote.yaml` is a manually dispatched workflow
that provides a convenience mechanism for promoting from 
`candidate` -> `stable`.

**Note** that the Github Actions settings will need to be 
altered such that the Github Token can write
changes to the repo, and there will need to be a
Secret created named `STORE_TOKEN` which can be
generated using `snapcraft export-login`, and needs 
permissions to manage the `zellij` snap on both
the `latest/candidate` and `latest/stable` tracks.

Fixes #2 