### PR TITLE
Fix snapcraft.yaml path

### DIFF
--- a/.github/workflows/update-snap.yaml
+++ b/.github/workflows/update-snap.yaml
@@ -27,7 +27,7 @@ jobs:
           LATEST=$(curl -sL https://api.github.com/repos/zellij-org/zellij/releases |
             jq .  | grep tag_name | head -n 1 | cut -d'"' -f4 | tr -d 'v'
           )
-          sed -i 's/^\(version: \).*$/\1'"$LATEST"'/' snap/snapcraft.yaml
+          sed -i 's/^\(version: \).*$/\1'"$LATEST"'/' snapcraft.yaml
           echo "version=$(LATEST)" >> $GITHUB_OUTPUT
 
       - name: Detect changes


### PR DESCRIPTION
#6 added CI for auto updating the snap, which attempts to take the snapcraft.yaml from the `snap/` folder, but here the yaml is in the root folder.

This PR updates the workflow accordingly.

Fixes #8 to #17 (and counting).