### PR TITLE
chore: bump to zellij 0.44.2

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: zellij
-version: 0.44.1
+version: 0.44.2
 summary: A terminal workspace
 description: |
   Zellij is a terminal workspace that aims to be a multi-purpose and flexible


### PR DESCRIPTION
Bumps to latest version - looks like the update workflow is disabled at the moment :-)